### PR TITLE
doc: fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1>Starbridge</h1>
 </div>
 <p align="center">
-<a href="https://github.com/stellar/starbridge/actions/workflows/go.yml"><img src="https://github.com/stellar/starlight/actions/workflows/go.yml/badge.svg" />
+<a href="https://github.com/stellar/starbridge/actions/workflows/go.yml"><img src="https://github.com/stellar/starbridge/actions/workflows/go.yml/badge.svg" />
 <a href="https://pkg.go.dev/github.com/stellar/starbridge"><img src="https://pkg.go.dev/badge/github.com/stellar/starbridge.svg" alt="Go Reference"></a>
 <a href="https://github.com/stellar/starbridge/discussions"><img src="https://img.shields.io/github/discussions/stellar/starbridge" alt="Discussions"></a>
 </p>


### PR DESCRIPTION
### What

Correct the URL for the build status badge in the readme.

### Why

Looks like I botched the copy-paste from the starlight repo and missed renaming one place.