### PR TITLE
Fix small bug

### DIFF
--- a/cmd/gravitybeam/collector.go
+++ b/cmd/gravitybeam/collector.go
@@ -75,7 +75,7 @@ func (c *Collector) Collect() error {
 		if err != nil {
 			return err
 		}
-		logger = c.logger.WithField("tx", hex.EncodeToString(hash[:]))
+		logger = logger.WithField("tx", hex.EncodeToString(hash[:]))
 		logger.Infof("tx received: sig count: %d", len(tx.Signatures()))
 
 		tx, err = c.store.StoreAndUpdate(hash, tx)


### PR DESCRIPTION
### What
Change which logger is used in handler to continue to use the copied logger.

### Why
The logger is copied at the beginning of the for loop to ensure any logger use within the for loop like adding fields is discarded for the next run.,