### PR TITLE
Enable mdns always

### DIFF
--- a/cmd/gravitybeam/main.go
+++ b/cmd/gravitybeam/main.go
@@ -69,14 +69,7 @@ func run(args []string, logger *supportlog.Entry) error {
 		logger.Infof("Listening for p2p on... %v", a)
 	}
 
-	if peers == "" {
-		logger.Info("Using mdns to discover local peers...")
-		mdnsService := mdns.NewMdnsService(host, "gravitybeam", &mdnsNotifee{Host: host, Logger: logger})
-		err = mdnsService.Start()
-		if err != nil {
-			return err
-		}
-	} else {
+	if peers != "" {
 		peersArr := strings.Split(peers, ",")
 		for _, p := range peersArr {
 			p := p
@@ -96,6 +89,13 @@ func run(args []string, logger *supportlog.Entry) error {
 				logger.Info("Connected to peer")
 			}()
 		}
+	}
+
+	logger.Info("Using mdns to discover local peers...")
+	mdnsService := mdns.NewMdnsService(host, "starbridge", &mdnsNotifee{Host: host, Logger: logger})
+	err = mdnsService.Start()
+	if err != nil {
+		return err
 	}
 
 	pubSub, err := pubsub.NewGossipSub(context.Background(), host)

--- a/cmd/starbridge/main.go
+++ b/cmd/starbridge/main.go
@@ -89,14 +89,7 @@ func run(args []string, logger *supportlog.Entry) error {
 		logger.Infof("Listening for p2p on... %v", a)
 	}
 
-	if peers == "" {
-		logger.Info("Using mdns to discover local peers...")
-		mdnsService := mdns.NewMdnsService(host, "gravitybeam", &mdnsNotifee{Host: host, Logger: logger})
-		err = mdnsService.Start()
-		if err != nil {
-			return err
-		}
-	} else {
+	if peers != "" {
 		peersArr := strings.Split(peers, ",")
 		for _, p := range peersArr {
 			p := p
@@ -116,6 +109,13 @@ func run(args []string, logger *supportlog.Entry) error {
 				logger.Info("Connected to peer")
 			}()
 		}
+	}
+
+	logger.Info("Using mdns to discover local peers...")
+	mdnsService := mdns.NewMdnsService(host, "starbridge", &mdnsNotifee{Host: host, Logger: logger})
+	err = mdnsService.Start()
+	if err != nil {
+		return err
 	}
 
 	pubSub, err := pubsub.NewGossipSub(context.Background(), host)

--- a/cmd/stellarwallet/main.go
+++ b/cmd/stellarwallet/main.go
@@ -77,14 +77,7 @@ func run(args []string, logger *supportlog.Entry) error {
 		logger.Infof("Listening for p2p on... %v", a)
 	}
 
-	if peers == "" {
-		logger.Info("Using mdns to discover local peers...")
-		mdnsService := mdns.NewMdnsService(host, "gravitybeam", &mdnsNotifee{Host: host, Logger: logger})
-		err = mdnsService.Start()
-		if err != nil {
-			return err
-		}
-	} else {
+	if peers != "" {
 		peersArr := strings.Split(peers, ",")
 		for _, p := range peersArr {
 			p := p
@@ -104,6 +97,13 @@ func run(args []string, logger *supportlog.Entry) error {
 				logger.Info("Connected to peer")
 			}()
 		}
+	}
+
+	logger.Info("Using mdns to discover local peers...")
+	mdnsService := mdns.NewMdnsService(host, "starbridge", &mdnsNotifee{Host: host, Logger: logger})
+	err = mdnsService.Start()
+	if err != nil {
+		return err
 	}
 
 	pubSub, err := pubsub.NewGossipSub(context.Background(), host)


### PR DESCRIPTION
### What
Enable mDNS always, not only when no peers are specified.

### Why
mDNS is only enabled when no peers are specified, but this is inconvenient when running local tests where I want the app to connect to a specific remote peer and serve up mDNS discoverability locally.