### PR TITLE
Publish to destination

### DIFF
--- a/cmd/gravitybeam/accounts.go
+++ b/cmd/gravitybeam/accounts.go
@@ -6,17 +6,29 @@ import (
 
 func Accounts(tx *txnbuild.Transaction) []string {
 	accountsMap := map[string]bool{}
+
 	accountsMap[tx.SourceAccount().AccountID] = true
+
 	for _, op := range tx.Operations() {
 		opSource := op.GetSourceAccount()
 		if opSource == "" {
 			continue
 		}
 		accountsMap[opSource] = true
+
+		switch o := op.(type) {
+		case *txnbuild.CreateClaimableBalance:
+			for _, claimant := range o.Destinations {
+				// TODO: Assess the predicate portion of the claimant?
+				accountsMap[claimant.Destination] = true
+			}
+		}
 	}
+
 	accounts := make([]string, 0, len(accountsMap))
 	for a := range accountsMap {
 		accounts = append(accounts, a)
 	}
+
 	return accounts
 }


### PR DESCRIPTION
### What
Gravitybeam publish to topic for destination accounts too.

### Why
Gravitybeam publishes to topics for the source accounts, but it should publish to the destination too so that the receiving wallet can subscribe to a topic just for itself.