### PR TITLE
Send to destination account even if source not set

### DIFF
--- a/cmd/gravitybeam/accounts.go
+++ b/cmd/gravitybeam/accounts.go
@@ -11,10 +11,9 @@ func Accounts(tx *txnbuild.Transaction) []string {
 
 	for _, op := range tx.Operations() {
 		opSource := op.GetSourceAccount()
-		if opSource == "" {
-			continue
+		if opSource != "" {
+			accountsMap[opSource] = true
 		}
-		accountsMap[opSource] = true
 
 		switch o := op.(type) {
 		case *txnbuild.CreateClaimableBalance:


### PR DESCRIPTION
### What
Send to destination account even if source not set.

### Why
The operation containing a movement of funds won't always have a source account, because the source may be the transaction source instead. In this case the app is skipping over looking at the destination details of the operation, but it needs to still do that so we still include the destination in the list of accounts to publish for.