### PR TITLE
Stellar modelTx.SeqNum should match stellarTx.seqNum

### DIFF
--- a/cmd/starbridge/integrations/stellar.go
+++ b/cmd/starbridge/integrations/stellar.go
@@ -57,7 +57,7 @@ func Transaction2Stellar(tx *model.Transaction) (*txnbuild.Transaction, error) {
 				Sequence:  int64(tx.SeqNum),
 			},
 			BaseFee:              baseFee,
-			IncrementSequenceNum: true,
+			IncrementSequenceNum: false,
 			Operations:           ops,
 			Timebounds:           txnbuild.NewInfiniteTimeout(),
 		},

--- a/cmd/starbridge/model/chain.go
+++ b/cmd/starbridge/model/chain.go
@@ -61,7 +61,8 @@ func nextStellarNonceFn(sourceAccount string) (uint64, error) {
 	if e != nil {
 		return 0, fmt.Errorf("error getting seq num: %s", e)
 	}
-	return uint64(seqNum), nil
+	incrementedSeqNum := uint64(seqNum) + 1
+	return incrementedSeqNum, nil
 }
 
 func unsupportedNonceForChain(sourceAccount string) (uint64, error) {


### PR DESCRIPTION
increment stellar seqNum when fetching nextSequenceNumber instead of having the sdk do it automatically, ensures modelTx seqNum matches stellarTx.SeqNum