### PR TITLE
Fix gravitybeam publishing

### DIFF
--- a/cmd/gravitybeam/collector.go
+++ b/cmd/gravitybeam/collector.go
@@ -93,12 +93,7 @@ func (c *Collector) Collect() error {
 		for _, a := range Accounts(tx) {
 			err = func() error {
 				logger.Infof("publishing to topic for %s", a)
-				t, err := c.pubSub.Join("starbridge-stellar-transactions-signed-" + a)
-				if err != nil {
-					return fmt.Errorf("joining topic to publish tx %s for account %s: %w", hash, a, err)
-				}
-				defer t.Close()
-				err = t.Publish(ctx, txBytes)
+				err = c.pubSub.Publish("starbridge-stellar-transactions-signed-" + a, txBytes)
 				if err != nil {
 					return fmt.Errorf("publishing tx %s for account %s: %w", hash, a, err)
 				}

--- a/cmd/gravitybeam/collector.go
+++ b/cmd/gravitybeam/collector.go
@@ -91,17 +91,11 @@ func (c *Collector) Collect() error {
 		}
 
 		for _, a := range Accounts(tx) {
-			err = func() error {
-				logger.Infof("publishing to topic for %s", a)
-				//nolint:staticcheck // SA1019 ignore this!
-				err = c.pubSub.Publish("starbridge-stellar-transactions-signed-" + a, txBytes)
-				if err != nil {
-					return fmt.Errorf("publishing tx %s for account %s: %w", hash, a, err)
-				}
-				return nil
-			}()
+			logger.Infof("publishing to topic for %s", a)
+			//nolint:staticcheck // SA1019 ignore this!
+			err = c.pubSub.Publish("starbridge-stellar-transactions-signed-"+a, txBytes)
 			if err != nil {
-				return err
+				return fmt.Errorf("publishing tx %s for account %s: %w", hash, a, err)
 			}
 		}
 	}

--- a/cmd/gravitybeam/collector.go
+++ b/cmd/gravitybeam/collector.go
@@ -93,7 +93,7 @@ func (c *Collector) Collect() error {
 		for _, a := range Accounts(tx) {
 			err = func() error {
 				logger.Infof("publishing to topic for %s", a)
-				//lint:ignore SA1019
+				//nolint:staticcheck // SA1004 ignore this!
 				err = c.pubSub.Publish("starbridge-stellar-transactions-signed-" + a, txBytes)
 				if err != nil {
 					return fmt.Errorf("publishing tx %s for account %s: %w", hash, a, err)

--- a/cmd/gravitybeam/collector.go
+++ b/cmd/gravitybeam/collector.go
@@ -93,7 +93,7 @@ func (c *Collector) Collect() error {
 		for _, a := range Accounts(tx) {
 			err = func() error {
 				logger.Infof("publishing to topic for %s", a)
-				//nolint:staticcheck // SA1004 ignore this!
+				//nolint:staticcheck // SA1019 ignore this!
 				err = c.pubSub.Publish("starbridge-stellar-transactions-signed-" + a, txBytes)
 				if err != nil {
 					return fmt.Errorf("publishing tx %s for account %s: %w", hash, a, err)

--- a/cmd/gravitybeam/collector.go
+++ b/cmd/gravitybeam/collector.go
@@ -93,6 +93,7 @@ func (c *Collector) Collect() error {
 		for _, a := range Accounts(tx) {
 			err = func() error {
 				logger.Infof("publishing to topic for %s", a)
+				//lint:ignore SA1019
 				err = c.pubSub.Publish("starbridge-stellar-transactions-signed-" + a, txBytes)
 				if err != nil {
 					return fmt.Errorf("publishing tx %s for account %s: %w", hash, a, err)


### PR DESCRIPTION
### What
Publish in gravitybeam without joining topic.

### Why
Something to do with the fact I'm joining a topic and closing it immediately is creating a problem where the message won't be propagated to listeners. There are publishing options I think I need to be using, but I still need to figure them out. In the interim publishing without being on the topic (a deprecated function) is the easiest way to make it work. Essentially the node never leaves the topic. This isn't great as the number of topics expands, but it'll do for now.