### PR TITLE
Organize shared p2p code into a p2p package

### DIFF
--- a/cmd/starbridge/main.go
+++ b/cmd/starbridge/main.go
@@ -8,12 +8,6 @@ import (
 	"strings"
 	"time"
 
-	libp2p "github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p-core/host"
-	libp2pnetwork "github.com/libp2p/go-libp2p-core/network"
-	"github.com/libp2p/go-libp2p-core/peer"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	ff "github.com/peterbourgon/ff/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/stellar/go/clients/horizonclient"
@@ -25,6 +19,7 @@ import (
 	"github.com/stellar/starbridge/cmd/starbridge/integrations"
 	"github.com/stellar/starbridge/cmd/starbridge/sigsharestellar"
 	"github.com/stellar/starbridge/cmd/starbridge/transform"
+	"github.com/stellar/starbridge/p2p"
 )
 
 func main() {
@@ -39,6 +34,8 @@ func main() {
 }
 
 func run(args []string, logger *supportlog.Entry) error {
+	ctx := context.Background()
+
 	fs := flag.NewFlagSet("starbridge", flag.ExitOnError)
 
 	txHash := ""
@@ -74,58 +71,13 @@ func run(args []string, logger *supportlog.Entry) error {
 		return err
 	}
 
-	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/" + portP2P))
-	if err != nil {
-		return err
-	}
-	host.Network().Notify(&libp2pnetwork.NotifyBundle{
-		ConnectedF: func(n libp2pnetwork.Network, c libp2pnetwork.Conn) {
-			logger := logger.WithField("peer", c.RemotePeer().Pretty())
-			logger.Info("Connected to peer")
-		},
+	pubSub, err := p2p.New(ctx, p2p.Config{
+		Logger: logger,
+		Port:   portP2P,
+		Peers:  strings.Split(peers, ","),
 	})
-	hostAddrInfo := peer.AddrInfo{
-		ID:    host.ID(),
-		Addrs: host.Addrs(),
-	}
-	hostAddrs, err := peer.AddrInfoToP2pAddrs(&hostAddrInfo)
 	if err != nil {
 		return err
-	}
-	for _, a := range hostAddrs {
-		logger.WithField("addr", a).Info("Listening")
-	}
-
-	if peers != "" {
-		peersArr := strings.Split(peers, ",")
-		for _, p := range peersArr {
-			p := p
-			go func() {
-				logger := logger.WithField("peer", p)
-				logger.Info("Connecting to peer...")
-				peerAddrInfo, err := peer.AddrInfoFromString(p)
-				if err != nil {
-					logger.Errorf("Error parsing peer address: %v", err)
-					return
-				}
-				err = host.Connect(context.Background(), *peerAddrInfo)
-				if err != nil {
-					logger.Errorf("Error connecting to peer: %v", err)
-					return
-				}
-			}()
-		}
-	}
-
-	mdnsService := mdns.NewMdnsService(host, "starbridge", &mdnsNotifee{Host: host, Logger: logger})
-	err = mdnsService.Start()
-	if err != nil {
-		return err
-	}
-
-	pubSub, err := pubsub.NewGossipSub(context.Background(), host)
-	if err != nil {
-		return fmt.Errorf("configuring pubsub: %v", err)
 	}
 
 	sigShareStellar, err := sigsharestellar.NewSigShareStellar(sigsharestellar.SigShareStellarConfig{
@@ -199,19 +151,4 @@ func signTxForStellar(tx *txnbuild.Transaction, seed string) (*txnbuild.Transact
 	}
 
 	return signedTx, nil
-}
-
-type mdnsNotifee struct {
-	Host   host.Host
-	Logger *supportlog.Entry
-}
-
-func (n *mdnsNotifee) HandlePeerFound(pi peer.AddrInfo) {
-	if pi.ID == n.Host.ID() {
-		return
-	}
-	err := n.Host.Connect(context.Background(), pi)
-	if err != nil {
-		n.Logger.WithStack(err).Error(fmt.Errorf("Error connecting to peer %s: %w", pi.ID.Pretty(), err))
-	}
 }

--- a/cmd/submitter/main.go
+++ b/cmd/submitter/main.go
@@ -7,16 +7,11 @@ import (
 	"os"
 	"strings"
 
-	libp2p "github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p-core/host"
-	libp2pnetwork "github.com/libp2p/go-libp2p-core/network"
-	"github.com/libp2p/go-libp2p-core/peer"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	ff "github.com/peterbourgon/ff/v3"
 	"github.com/sirupsen/logrus"
 	"github.com/stellar/go/clients/horizonclient"
 	supportlog "github.com/stellar/go/support/log"
+	"github.com/stellar/starbridge/p2p"
 )
 
 func main() {
@@ -30,6 +25,8 @@ func main() {
 }
 
 func run(args []string, logger *supportlog.Entry) error {
+	ctx := context.Background()
+
 	fs := flag.NewFlagSet("submitter", flag.ExitOnError)
 
 	portP2P := "0"
@@ -54,58 +51,13 @@ func run(args []string, logger *supportlog.Entry) error {
 		return err
 	}
 
-	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/" + portP2P))
-	if err != nil {
-		return err
-	}
-	host.Network().Notify(&libp2pnetwork.NotifyBundle{
-		ConnectedF: func(n libp2pnetwork.Network, c libp2pnetwork.Conn) {
-			logger := logger.WithField("peer", c.RemotePeer().Pretty())
-			logger.Info("Connected to peer")
-		},
+	pubSub, err := p2p.New(ctx, p2p.Config{
+		Logger: logger,
+		Port:   portP2P,
+		Peers:  strings.Split(peers, ","),
 	})
-	hostAddrInfo := peer.AddrInfo{
-		ID:    host.ID(),
-		Addrs: host.Addrs(),
-	}
-	hostAddrs, err := peer.AddrInfoToP2pAddrs(&hostAddrInfo)
 	if err != nil {
 		return err
-	}
-	for _, a := range hostAddrs {
-		logger.WithField("addr", a).Info("Listening")
-	}
-
-	if peers != "" {
-		peersArr := strings.Split(peers, ",")
-		for _, p := range peersArr {
-			p := p
-			go func() {
-				logger := logger.WithField("peer", p)
-				logger.Info("Connecting to peer...")
-				peerAddrInfo, err := peer.AddrInfoFromString(p)
-				if err != nil {
-					logger.Errorf("Error parsing peer address: %v", err)
-					return
-				}
-				err = host.Connect(context.Background(), *peerAddrInfo)
-				if err != nil {
-					logger.Errorf("Error connecting to peer: %v", err)
-					return
-				}
-			}()
-		}
-	}
-
-	mdnsService := mdns.NewMdnsService(host, "starbridge", &mdnsNotifee{Host: host, Logger: logger})
-	err = mdnsService.Start()
-	if err != nil {
-		return err
-	}
-
-	pubSub, err := pubsub.NewGossipSub(context.Background(), host)
-	if err != nil {
-		return fmt.Errorf("configuring pubsub: %v", err)
 	}
 
 	collector, err := NewCollector(CollectorConfig{
@@ -123,19 +75,4 @@ func run(args []string, logger *supportlog.Entry) error {
 	}
 
 	return nil
-}
-
-type mdnsNotifee struct {
-	Host   host.Host
-	Logger *supportlog.Entry
-}
-
-func (n *mdnsNotifee) HandlePeerFound(pi peer.AddrInfo) {
-	if pi.ID == n.Host.ID() {
-		return
-	}
-	err := n.Host.Connect(context.Background(), pi)
-	if err != nil {
-		n.Logger.WithStack(err).Error(fmt.Errorf("Error connecting to peer %s: %w", pi.ID.Pretty(), err))
-	}
 }

--- a/p2p/setup.go
+++ b/p2p/setup.go
@@ -72,7 +72,11 @@ func New(ctx context.Context, c Config) (*pubsub.PubSub, error) {
 		})
 	}
 	_ = g.Wait()
-	logger.Errorf("Connected to %d peers", connected)
+	if connected > 0 {
+		logger.Infof("Connected to %d peers", connected)
+	} else {
+		logger.Warnf("Connected to %d peers", connected)
+	}
 
 	mdnsService := mdns.NewMdnsService(host, "starbridge", &mdnsNotifee{Host: host, Logger: logger})
 	err = mdnsService.Start()

--- a/p2p/setup.go
+++ b/p2p/setup.go
@@ -1,0 +1,100 @@
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
+	supportlog "github.com/stellar/go/support/log"
+	"golang.org/x/sync/errgroup"
+)
+
+type Config struct {
+	Logger *supportlog.Entry
+	Port   string
+	Peers  []string
+}
+
+func New(ctx context.Context, c Config) (*pubsub.PubSub, error) {
+	logger := c.Logger
+
+	host, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/" + c.Port))
+	if err != nil {
+		return nil, err
+	}
+	host.Network().Notify(&network.NotifyBundle{
+		ConnectedF: func(n network.Network, c network.Conn) {
+			logger := logger.WithField("peer", c.RemotePeer().Pretty())
+			logger.Info("Connected to peer")
+		},
+	})
+	hostAddrInfo := peer.AddrInfo{
+		ID:    host.ID(),
+		Addrs: host.Addrs(),
+	}
+	hostAddrs, err := peer.AddrInfoToP2pAddrs(&hostAddrInfo)
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range hostAddrs {
+		logger.WithField("addr", a).Info("Listening")
+	}
+
+	connected := uint64(0)
+	g := errgroup.Group{}
+	for _, p := range c.Peers {
+		p := p
+		g.Go(func() error {
+			logger := logger.WithField("peer", p)
+			logger.Info("Connecting to peer...")
+			peerAddrInfo, err := peer.AddrInfoFromString(p)
+			if err != nil {
+				logger.Errorf("Error parsing peer address: %v", err)
+				return nil
+			}
+			err = host.Connect(ctx, *peerAddrInfo)
+			if err != nil {
+				logger.Errorf("Error connecting to peer: %v", err)
+				return nil
+			}
+			atomic.AddUint64(&connected, 1)
+			return nil
+		})
+	}
+	_ = g.Wait()
+	logger.Errorf("Connected to %d peers", connected)
+
+	mdnsService := mdns.NewMdnsService(host, "starbridge", &mdnsNotifee{Host: host, Logger: logger})
+	err = mdnsService.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	pubSub, err := pubsub.NewGossipSub(context.Background(), host)
+	if err != nil {
+		return nil, fmt.Errorf("configuring pubsub: %v", err)
+	}
+
+	return pubSub, nil
+}
+
+type mdnsNotifee struct {
+	Host   host.Host
+	Logger *supportlog.Entry
+}
+
+func (n *mdnsNotifee) HandlePeerFound(pi peer.AddrInfo) {
+	if pi.ID == n.Host.ID() {
+		return
+	}
+	err := n.Host.Connect(context.Background(), pi)
+	if err != nil {
+		n.Logger.WithStack(err).Error(fmt.Errorf("Error connecting to peer %s: %w", pi.ID.Pretty(), err))
+	}
+}

--- a/p2p/setup.go
+++ b/p2p/setup.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 
 	"github.com/libp2p/go-libp2p"
@@ -49,7 +50,10 @@ func New(ctx context.Context, c Config) (*pubsub.PubSub, error) {
 	connected := uint64(0)
 	g := errgroup.Group{}
 	for _, p := range c.Peers {
-		p := p
+		p := strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
 		g.Go(func() error {
 			logger := logger.WithField("peer", p)
 			logger.Info("Connecting to peer...")


### PR DESCRIPTION
### What
Organize shared p2p code into a p2p package.

### Why
The three apps have identical p2p network setup code. It has become a bit tedious when iterating on the p2p code to change it in three places. I kept them isolated because I wasn't sure how much they'd diverge, but over time they haven't diverged so far. If they end up diverging I can unwind this refactor at that point.