### PR TITLE
Add golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+run:
+  modules-download-mode: readonly
+
+linters:
+  # Enable these linters in addition to the default linters that golangci-lint starts with.
+  enable:
+    - gofmt
+    - gofumpt
+
+linters-settings:
+  gofmt:
+    simplify: true


### PR DESCRIPTION
### What
Add golangci-lint config using the config we've used on some other projects.

### Why
Consistent linting.