### PR TITLE
Publish messages to different topics for different chains

### DIFF
--- a/cmd/starbridge/sigsharestellar/sigsharestellar.go
+++ b/cmd/starbridge/sigsharestellar/sigsharestellar.go
@@ -26,7 +26,7 @@ type SigShareStellar struct {
 }
 
 func NewSigShareStellar(config SigShareStellarConfig) (*SigShareStellar, error) {
-	topic, err := config.PubSub.Join("starbridge-stellar-transactions-signed")
+	topic, err := config.PubSub.Join("starbridge-messages-signed")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/submitter/collector.go
+++ b/cmd/submitter/collector.go
@@ -31,7 +31,7 @@ type Collector struct {
 }
 
 func NewCollector(config CollectorConfig) (*Collector, error) {
-	topic, err := config.PubSub.Join("starbridge-stellar-transactions-signed-aggregated")
+	topic, err := config.PubSub.Join("starbridge-messages-signed-aggregated-stellar")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What
Publish messages in gravitybeam to different topics for different chains.

### Why
The submitter for Stellar and Ethereum wallets probably don't want to subscribe to messages about other chains.