### PR TITLE
Change license of contracts to Apache 2.0

### DIFF
--- a/solidity/contracts/Auth.sol
+++ b/solidity/contracts/Auth.sol
@@ -1,5 +1,5 @@
 // contracts/Auth.sol
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";

--- a/solidity/contracts/Bridge.sol
+++ b/solidity/contracts/Bridge.sol
@@ -1,5 +1,5 @@
 // contracts/Auth.sol
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 import "./Auth.sol";
 import "./StellarAsset.sol";

--- a/solidity/contracts/StellarAsset.sol
+++ b/solidity/contracts/StellarAsset.sol
@@ -1,5 +1,5 @@
 // contracts/Auth.sol
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/solidity/contracts/StellarAssetFactory.sol
+++ b/solidity/contracts/StellarAssetFactory.sol
@@ -1,5 +1,5 @@
 // contracts/Auth.sol
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 import "./Auth.sol";
 import "./StellarAsset.sol";

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -8,7 +8,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.4",
     "@nomiclabs/hardhat-waffle": "^2.0.2",


### PR DESCRIPTION
### What
Change license of contracts to Apache 2.0.

### Why
The code in this repository is intended to be licensed only with the Apache License 2.0, as is most software products produced by @stellar. Looks like we accidentally committed contracts with a combination of ISC and MIT licensing.