### PR TITLE
Move Stellar tx observer to main backend worker

### DIFF
--- a/app.go
+++ b/app.go
@@ -36,7 +36,6 @@ func NewApp(config Config) *App {
 
 	app.initHTTP(config)
 	app.initWorker()
-	app.initStellarTxObserver()
 	app.initLogger()
 	app.initPrometheus()
 
@@ -61,13 +60,7 @@ func (a *App) initWorker() {
 			NetworkPassphrase: network.TestNetworkPassphrase,
 			SecretKey:         "SAV3VE7CMIDIY5GWPZ3WPTMXCD342CGRVKP2SHX4FHAU5D35QW7HNJLS",
 		},
-	}
-}
-
-func (a *App) initStellarTxObserver() {
-	a.stellarObserver = &txobserver.Observer{
-		Store:  a.store,
-		Client: horizonclient.DefaultTestNetClient,
+		StellarObserver: txobserver.NewObserver(horizonclient.DefaultTestNetClient, a.store),
 	}
 }
 
@@ -98,14 +91,5 @@ func (a *App) RunBackendWorker() {
 	err := a.worker.Run()
 	if err != nil {
 		log.WithField("error", err).Error("error running backend worker")
-	}
-}
-
-// RunStellarTxObserver starts backend worker responsible for observing Stellar
-// transactions
-func (a *App) RunStellarTxObserver() {
-	err := a.stellarObserver.Run()
-	if err != nil {
-		log.WithField("error", err).Error("error running stellar tx observer")
 	}
 }

--- a/app.go
+++ b/app.go
@@ -18,8 +18,6 @@ type App struct {
 	worker     *backend.Worker
 	store      *store.Memory
 
-	stellarObserver *txobserver.Observer
-
 	prometheusRegistry *prometheus.Registry
 }
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ func main() {
 	})
 	go app.RunHTTPServer()
 	go app.RunBackendWorker()
-	go app.RunStellarTxObserver()
 	ch := make(chan bool)
 	<-ch
 }


### PR DESCRIPTION
This commit moves Stellar tx observer to be run in the same go routine as backend worker. Both the worker and observer update the outgoing Stellar transactions state in a DB. Doing this in two go routines adds complexity to prevent race conditions in the code. In the new code the worker will always call observer to process all the latest ledgers before processing signing requests.