### PR TITLE
Add config file parsing and graceful shutdown

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -170,10 +170,7 @@ func (a *App) RunHTTPServer() {
 // RunBackendWorker starts backend worker responsible for building and signing
 // transactions
 func (a *App) RunBackendWorker() {
-	err := a.worker.Run()
-	if err != nil {
-		log.WithField("error", err).Error("error running backend worker")
-	}
+	a.worker.Run()
 }
 
 func (a *App) Close() {

--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,12 @@
 package app
 
 import (
+	"context"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
@@ -15,6 +21,9 @@ import (
 )
 
 type App struct {
+	appCtx    context.Context
+	cancelCtx context.CancelFunc
+
 	httpServer *httpx.Server
 	worker     *backend.Worker
 	store      *store.DB
@@ -23,16 +32,16 @@ type App struct {
 }
 
 type Config struct {
-	Port      uint16
-	AdminPort uint16
+	Port      uint16 `valid:"-"`
+	AdminPort uint16 `toml:"admin_port" valid:"-"`
 
-	PostgresDSN string
+	PostgresDSN string `toml:"postgres_dsn" valid:"-"`
 
-	HorizonURL        string
-	NetworkPassphrase string
+	HorizonURL        string `toml:"horizon_url" valid:"-"`
+	NetworkPassphrase string `toml:"network_passphrase" valid:"-"`
 
-	MainAccountID string
-	SignerKey     *keypair.Full
+	MainAccountID   string `toml:"main_account_id" valid:"stellar_accountid"`
+	SignerSecretKey string `toml:"signer_secret_key" valid:"optional,stellar_seed"`
 }
 
 func NewApp(config Config) *App {
@@ -41,6 +50,7 @@ func NewApp(config Config) *App {
 		prometheusRegistry: prometheus.NewRegistry(),
 	}
 
+	app.initGracefulShutdown()
 	app.initHTTP(config)
 	app.initWorker(config)
 	app.initStore(config)
@@ -48,6 +58,23 @@ func NewApp(config Config) *App {
 	app.initPrometheus()
 
 	return app
+}
+
+func (a *App) initGracefulShutdown() {
+	a.appCtx, a.cancelCtx = context.WithCancel(context.Background())
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		select {
+		case <-signalChan:
+			log.Info("Shutdown signal received...")
+			a.Close()
+		case <-a.appCtx.Done():
+			return
+		}
+	}()
 }
 
 func (a *App) initPrometheus() {
@@ -72,7 +99,19 @@ func (a *App) initStore(config Config) {
 }
 
 func (a *App) initWorker(config Config) {
+	var (
+		signerKey *keypair.Full
+		err       error
+	)
+	if config.SignerSecretKey != "" {
+		signerKey, err = keypair.ParseFull(config.SignerSecretKey)
+		if err != nil {
+			log.Fatalf("cannot pase signer secret key: %v", err)
+		}
+	}
+
 	a.worker = &backend.Worker{
+		Ctx:   a.appCtx,
 		Store: a.store,
 		StellarBuilder: &txbuilder.Builder{
 			HorizonURL:    config.HorizonURL,
@@ -80,14 +119,15 @@ func (a *App) initWorker(config Config) {
 		},
 		StellarSigner: &signer.Signer{
 			NetworkPassphrase: config.NetworkPassphrase,
-			Signer:            config.SignerKey,
+			Signer:            signerKey,
 		},
-		StellarObserver: txobserver.NewObserver(horizonclient.DefaultTestNetClient, a.store),
+		StellarObserver: txobserver.NewObserver(a.appCtx, horizonclient.DefaultTestNetClient, a.store),
 	}
 }
 
 func (a *App) initHTTP(config Config) {
 	httpServer, err := httpx.NewServer(httpx.ServerConfig{
+		Ctx:                a.appCtx,
 		Port:               config.Port,
 		AdminPort:          config.AdminPort,
 		PrometheusRegistry: a.prometheusRegistry,
@@ -97,6 +137,26 @@ func (a *App) initHTTP(config Config) {
 		log.Fatal("unable to create http server", err)
 	}
 	a.httpServer = httpServer
+}
+
+// Run starts all services and block until they are gracefully shut down.
+func (a *App) Run() {
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		a.RunHTTPServer()
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		a.RunBackendWorker()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	log.Info("Bye")
 }
 
 // RunHTTPServer starts http server
@@ -117,5 +177,5 @@ func (a *App) RunBackendWorker() {
 }
 
 func (a *App) Close() {
-	// TODO
+	a.cancelCtx()
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -34,16 +34,12 @@ type Worker struct {
 	log *log.Entry
 }
 
-func (w *Worker) Run() error {
+func (w *Worker) Run() {
 	w.log = log.WithField("service", "backend")
 
 	w.log.Info("Starting worker")
 
-	for {
-		if w.Ctx.Err() != nil {
-			return nil
-		}
-
+	for w.Ctx.Err() == nil {
 		// Process all new ledgers before processing signature requests
 		w.StellarObserver.ProcessNewLedgers()
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -23,6 +23,8 @@ var (
 )
 
 type Worker struct {
+	Ctx context.Context
+
 	Store *store.DB
 
 	StellarBuilder  *txbuilder.Builder
@@ -38,6 +40,10 @@ func (w *Worker) Run() error {
 	w.log.Info("Starting worker")
 
 	for {
+		if w.Ctx.Err() != nil {
+			return nil
+		}
+
 		// Process all new ledgers before processing signature requests
 		w.StellarObserver.ProcessNewLedgers()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,35 +7,32 @@ import (
 	"github.com/stellar/starbridge/app"
 )
 
-var (
-	RootCmd = &cobra.Command{
-		Use:           "starbridge",
-		Short:         "starbridge validator software",
-		SilenceErrors: true,
-		SilenceUsage:  true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			var (
-				cfg     app.Config
-				cfgPath = cmd.PersistentFlags().Lookup("conf").Value.String()
-			)
+var RootCmd = &cobra.Command{
+	Use:           "starbridge",
+	Short:         "starbridge validator software",
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var (
+			cfg     app.Config
+			cfgPath = cmd.PersistentFlags().Lookup("conf").Value.String()
+		)
 
-			err := config.Read(cfgPath, &cfg)
-
-			if err != nil {
-				switch cause := errors.Cause(err).(type) {
-				case *config.InvalidConfigError:
-					return errors.Wrap(cause, "config file")
-				default:
-					return err
-				}
+		err := config.Read(cfgPath, &cfg)
+		if err != nil {
+			switch cause := errors.Cause(err).(type) {
+			case *config.InvalidConfigError:
+				return errors.Wrap(cause, "config file")
+			default:
+				return err
 			}
+		}
 
-			app := app.NewApp(cfg)
-			app.Run()
-			return nil
-		},
-	}
-)
+		app := app.NewApp(cfg)
+		app.Run()
+		return nil
+	},
+}
 
 func init() {
 	RootCmd.PersistentFlags().String("conf", "./starbridge.cfg", "config file path")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/support/config"
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/starbridge/app"
+)
+
+var (
+	RootCmd = &cobra.Command{
+		Use:           "starbridge",
+		Short:         "starbridge validator software",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var (
+				cfg     app.Config
+				cfgPath = cmd.PersistentFlags().Lookup("conf").Value.String()
+			)
+
+			err := config.Read(cfgPath, &cfg)
+
+			if err != nil {
+				switch cause := errors.Cause(err).(type) {
+				case *config.InvalidConfigError:
+					log.Fatal("config file: ", cause)
+				default:
+					log.Fatal(err)
+				}
+			}
+
+			app := app.NewApp(cfg)
+			app.Run()
+			return nil
+		},
+	}
+)
+
+func init() {
+	RootCmd.PersistentFlags().String("conf", "./starbridge.cfg", "config file path")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/support/config"
-	"github.com/stellar/go/support/log"
+	"github.com/stellar/go/support/errors"
 	"github.com/stellar/starbridge/app"
 )
 
@@ -25,9 +24,9 @@ var (
 			if err != nil {
 				switch cause := errors.Cause(err).(type) {
 				case *config.InvalidConfigError:
-					log.Fatal("config file: ", cause)
+					return errors.Wrap(cause, "config file")
 				default:
-					log.Fatal(err)
+					return err
 				}
 			}
 

--- a/httpx/server.go
+++ b/httpx/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/middleware"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/cors"
 	"github.com/stellar/go/support/errors"
 	stellarhttp "github.com/stellar/go/support/http"
 	"github.com/stellar/go/support/log"
@@ -26,6 +27,7 @@ type TLSConfig struct {
 }
 
 type ServerConfig struct {
+	Ctx                context.Context
 	Port               uint16
 	AdminPort          uint16
 	TLSConfig          *TLSConfig
@@ -35,6 +37,8 @@ type ServerConfig struct {
 
 type Server struct {
 	Metrics *ServerMetrics
+
+	ctx context.Context
 
 	server      *http.Server
 	adminServer *http.Server
@@ -58,6 +62,8 @@ func NewServer(serverConfig ServerConfig) (*Server, error) {
 
 	server := &Server{
 		Metrics: metrics,
+
+		ctx: serverConfig.Ctx,
 
 		prometheusRegistry: serverConfig.PrometheusRegistry,
 		tlsConfig:          serverConfig.TLSConfig,
@@ -87,6 +93,12 @@ func (s *Server) initMux() {
 
 	// Public middlewares
 	mux.Use(middleware.StripSlashes)
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"*"},
+		AllowedHeaders: []string{"*"},
+		ExposedHeaders: []string{"Date"},
+	})
+	mux.Use(c.Handler)
 	mux.Use(middleware.NoCache)
 	mux.Use(prometheusMiddleware(s.Metrics))
 	mux.Use(middleware.Timeout(10 * time.Second))
@@ -119,6 +131,14 @@ func (s *Server) RegisterMetrics(registry *prometheus.Registry) {
 }
 
 func (s *Server) Serve() error {
+	go func() {
+		<-s.ctx.Done()
+		if s.adminServer != nil {
+			s.adminServer.Shutdown(context.Background())
+		}
+		s.server.Shutdown(context.Background())
+	}()
+
 	if s.adminServer != nil {
 		go func() {
 			log.Infof("starting admin server on %s", s.adminServer.Addr)
@@ -135,6 +155,11 @@ func (s *Server) Serve() error {
 	} else {
 		err = s.server.ListenAndServe()
 	}
+
+	if err == http.ErrServerClosed {
+		return nil
+	}
+
 	return err
 }
 

--- a/httpx/server.go
+++ b/httpx/server.go
@@ -134,9 +134,9 @@ func (s *Server) Serve() error {
 	go func() {
 		<-s.ctx.Done()
 		if s.adminServer != nil {
-			s.adminServer.Shutdown(context.Background())
+			_ = s.adminServer.Shutdown(context.Background())
 		}
-		s.server.Shutdown(context.Background())
+		_ = s.server.Shutdown(context.Background())
 	}()
 
 	if s.adminServer != nil {

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -214,8 +214,8 @@ func (i *Test) StartStarbridge(id int) error {
 		HorizonURL:  fmt.Sprintf("http://%s:8000/", dockerHost),
 		PostgresDSN: fmt.Sprintf("postgres://postgres:mysecretpassword@%s:5641/starbridge%d?sslmode=disable", dockerHost, id),
 
-		MainAccountID: i.mainKey.Address(),
-		SignerKey:     i.signerKeys[id],
+		MainAccountID:   i.mainKey.Address(),
+		SignerSecretKey: i.signerKeys[id].Seed(),
 
 		NetworkPassphrase: StandaloneNetworkPassphrase,
 	})

--- a/main.go
+++ b/main.go
@@ -1,7 +1,13 @@
 package main
 
-import "github.com/stellar/starbridge/cmd"
+import (
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/starbridge/cmd"
+)
 
 func main() {
-	cmd.RootCmd.Execute()
+	err := cmd.RootCmd.Execute()
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,16 +1,7 @@
 package main
 
-import "github.com/stellar/starbridge/app"
+import "github.com/stellar/starbridge/cmd"
 
 func main() {
-	app := app.NewApp(app.Config{
-		Port:      8000,
-		AdminPort: 6666,
-
-		PostgresDSN: "postgres://localhost:5432/starbridge?sslmode=disable",
-	})
-	go app.RunHTTPServer()
-	go app.RunBackendWorker()
-	ch := make(chan bool)
-	<-ch
+	cmd.RootCmd.Execute()
 }

--- a/starbridge_example.cfg
+++ b/starbridge_example.cfg
@@ -1,0 +1,4 @@
+port=8000
+admin_port=6060
+postgres_dsn="postgres://localhost:5432/starbridge?sslmode=disable"
+main_account_id="GD6FUM7LF762FFNT2R6JBGX6ME6KXUO7P4FRVFZZR25OMIUGHFSFT66R"


### PR DESCRIPTION
Use `github.com/stellar/go/support/config` to parse TOML config file and add graceful shutdown to HTTP server and backend worker.