### PR TITLE
Add ethereum signer

### DIFF
--- a/ethereum/signer.go
+++ b/ethereum/signer.go
@@ -1,0 +1,142 @@
+package ethereum
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/stellar/go/support/log"
+	"github.com/stellar/starbridge/solidity-go"
+)
+
+var (
+	uint256           = mustType("uint256")
+	bytes32           = mustType("bytes32")
+	withdrawERC20Type = mustTupleType([]abi.ArgumentMarshaling{
+		{Name: "id", Type: "bytes32"},
+		{Name: "expiration", Type: "uint256"},
+		{Name: "recipient", Type: "address"},
+		{Name: "token", Type: "address"},
+		{Name: "amount", Type: "uint256"},
+	})
+	withdrawETHType = mustTupleType([]abi.ArgumentMarshaling{
+		{Name: "id", Type: "bytes32"},
+		{Name: "expiration", Type: "uint256"},
+		{Name: "recipient", Type: "address"},
+		{Name: "amount", Type: "uint256"},
+	})
+)
+
+func mustType(t string) abi.Type {
+	ty, err := abi.NewType(t, t, nil)
+	if err != nil {
+		log.Fatalf("%v invalid type %v", t, err)
+	}
+	return ty
+}
+
+func mustTupleType(components []abi.ArgumentMarshaling) abi.Type {
+	ty, err := abi.NewType("tuple", "", components)
+	if err != nil {
+		log.Fatalf("invalid type %v", err)
+	}
+	return ty
+}
+
+// Signer represents an ethereum validator account which is
+// authorized to approve withdrawals from the bridge smart contract.
+type Signer struct {
+	privateKey *ecdsa.PrivateKey
+	version    *big.Int
+	address    common.Address
+}
+
+// NewSigner constructs a new Signer instance
+func NewSigner(privateKey string, bridgeConfigVersion int) (Signer, error) {
+	parsed, err := crypto.HexToECDSA(privateKey)
+	if err != nil {
+		return Signer{}, err
+	}
+	return Signer{
+		privateKey: parsed,
+		version:    big.NewInt(int64(bridgeConfigVersion)),
+		address:    crypto.PubkeyToAddress(parsed.PublicKey),
+	}, nil
+}
+
+// Address returns the ethereum address corresponding to the public
+// key of the signer
+func (s Signer) Address() common.Address {
+	return s.address
+}
+
+// SignWithdrawal returns a signature for the given withdrawal request
+func (s Signer) SignWithdrawal(
+	id common.Hash,
+	expiration int64,
+	recipient,
+	token common.Address, // an address of 0x0 indicates an ETH transfer
+	amount *big.Int,
+) ([]byte, error) {
+	if token == (common.Address{}) {
+		return s.signWithdrawETHRequest(solidity.WithdrawETHRequest{
+			Id:         id,
+			Expiration: big.NewInt(expiration),
+			Recipient:  recipient,
+			Amount:     amount,
+		})
+	} else {
+		return s.signWithdrawERC20Request(solidity.WithdrawERC20Request{
+			Id:         id,
+			Expiration: big.NewInt(expiration),
+			Recipient:  recipient,
+			Token:      token,
+			Amount:     amount,
+		})
+	}
+
+}
+
+func (s Signer) signWithdrawERC20Request(request solidity.WithdrawERC20Request) ([]byte, error) {
+	arguments := abi.Arguments{
+		{Type: uint256},
+		{Type: bytes32},
+		{Type: withdrawERC20Type},
+	}
+
+	abiEncoded, err := arguments.Pack(
+		s.version,
+		crypto.Keccak256Hash([]byte("withdrawERC20")),
+		request,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return s.signPayload(abiEncoded)
+}
+
+func (s Signer) signWithdrawETHRequest(request solidity.WithdrawETHRequest) ([]byte, error) {
+	arguments := abi.Arguments{
+		{Type: uint256},
+		{Type: bytes32},
+		{Type: withdrawETHType},
+	}
+
+	abiEncoded, err := arguments.Pack(
+		s.version,
+		crypto.Keccak256Hash([]byte("withdrawETH")),
+		request,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return s.signPayload(abiEncoded)
+}
+
+func (s Signer) signPayload(abiEncoded []byte) ([]byte, error) {
+	return crypto.Sign(accounts.TextHash(crypto.Keccak256(abiEncoded)), s.privateKey)
+}

--- a/ethereum/signer.go
+++ b/ethereum/signer.go
@@ -98,7 +98,6 @@ func (s Signer) SignWithdrawal(
 			Amount:     amount,
 		})
 	}
-
 }
 
 func (s Signer) signWithdrawERC20Request(request solidity.WithdrawERC20Request) ([]byte, error) {

--- a/ethereum/signer_test.go
+++ b/ethereum/signer_test.go
@@ -2,11 +2,12 @@ package ethereum
 
 import (
 	"encoding/hex"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"strings"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
 )
 
 func createSigner(t *testing.T) Signer {

--- a/ethereum/signer_test.go
+++ b/ethereum/signer_test.go
@@ -1,0 +1,70 @@
+package ethereum
+
+import (
+	"encoding/hex"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+func createSigner(t *testing.T) Signer {
+	signer, err := NewSigner(
+		"51138e68e8a5fa906d38c5b42bc01b805d7adb3fce037743fb406bb10aa83307",
+		0,
+	)
+	assert.NoError(t, err)
+	return signer
+}
+
+func TestSigner_Address(t *testing.T) {
+	signer := createSigner(t)
+	assert.Equal(
+		t,
+		common.HexToAddress("0xAe1B35129e5924C3a7313EE579878f829f3e8495"),
+		signer.Address(),
+	)
+}
+
+func TestSigner_SignWithdrawal(t *testing.T) {
+	signer := createSigner(t)
+	for _, withdrawal := range []struct {
+		id         common.Hash
+		expiration int64
+		recipient  common.Address
+		token      common.Address
+		amount     *big.Int
+		expected   string
+	}{
+		{
+			id:         common.HexToHash("0x99"),
+			expiration: 100,
+			recipient:  common.HexToAddress("0x123"),
+			token:      common.HexToAddress("0x456"),
+			amount:     big.NewInt(200),
+			expected:   "2a4fead286732e459cc4f167aa34f6ca6b83fa4e7c993429582a048020a4c2840f47a9903257266605de9975d2122d1db8697b7398474889aafaa3c9d1b4bd6c01",
+		},
+		{
+			id:         common.HexToHash("0x55"),
+			expiration: 200,
+			recipient:  common.HexToAddress("0x321"),
+			amount:     big.NewInt(100),
+			expected:   "40cd596f0d1683bbe42c6fc57220ecfda15d78d5ce9ccdf68c4da4d9a4d1a6bf63d249d59b17ead7c59b4b4da9755aad6eb9eefe656685322de074128370d31e01",
+		},
+	} {
+		signature, err := signer.SignWithdrawal(
+			withdrawal.id,
+			withdrawal.expiration,
+			withdrawal.recipient,
+			withdrawal.token,
+			withdrawal.amount,
+		)
+		assert.NoError(t, err)
+		assert.Equal(
+			t,
+			strings.ToLower(withdrawal.expected),
+			strings.ToLower(hex.EncodeToString(signature)),
+		)
+	}
+}

--- a/ethereum/signer_test.go
+++ b/ethereum/signer_test.go
@@ -44,14 +44,14 @@ func TestSigner_SignWithdrawal(t *testing.T) {
 			recipient:  common.HexToAddress("0x123"),
 			token:      common.HexToAddress("0x456"),
 			amount:     big.NewInt(200),
-			expected:   "2a4fead286732e459cc4f167aa34f6ca6b83fa4e7c993429582a048020a4c2840f47a9903257266605de9975d2122d1db8697b7398474889aafaa3c9d1b4bd6c01",
+			expected:   "2a4fead286732e459cc4f167aa34f6ca6b83fa4e7c993429582a048020a4c2840f47a9903257266605de9975d2122d1db8697b7398474889aafaa3c9d1b4bd6c1c",
 		},
 		{
 			id:         common.HexToHash("0x55"),
 			expiration: 200,
 			recipient:  common.HexToAddress("0x321"),
 			amount:     big.NewInt(100),
-			expected:   "40cd596f0d1683bbe42c6fc57220ecfda15d78d5ce9ccdf68c4da4d9a4d1a6bf63d249d59b17ead7c59b4b4da9755aad6eb9eefe656685322de074128370d31e01",
+			expected:   "40cd596f0d1683bbe42c6fc57220ecfda15d78d5ce9ccdf68c4da4d9a4d1a6bf63d249d59b17ead7c59b4b4da9755aad6eb9eefe656685322de074128370d31e1c",
 		},
 	} {
 		signature, err := signer.SignWithdrawal(


### PR DESCRIPTION
The `Signer` implementation will be used by the validator to sign ethereum withdrawal requests. The signatures produced by `Signer` will be validated by the bridge ethereum smart contract 