### PR TITLE
Add catchup mode to Stellar Observer

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -44,11 +44,10 @@ type Config struct {
 
 	PostgresDSN string `toml:"postgres_dsn" valid:"-"`
 
-	HorizonURL                         string `toml:"horizon_url" valid:"-"`
-	NetworkPassphrase                  string `toml:"network_passphrase" valid:"-"`
-	StellarBridgeAccount               string `toml:"stellar_bridge_account" valid:"stellar_accountid"`
-	StellarBridgeAccountCreateSequence uint32 `toml:"stellar_bridge_account_create_sequence" valid:"int"`
-	StellarPrivateKey                  string `toml:"stellar_private_key" valid:"stellar_seed"`
+	HorizonURL           string `toml:"horizon_url" valid:"-"`
+	NetworkPassphrase    string `toml:"network_passphrase" valid:"-"`
+	StellarBridgeAccount string `toml:"stellar_bridge_account" valid:"stellar_accountid"`
+	StellarPrivateKey    string `toml:"stellar_private_key" valid:"stellar_seed"`
 
 	EthereumRPCURL              string `toml:"ethereum_rpc_url" valid:"-"`
 	EthereumBridgeAddress       string `toml:"ethereum_bridge_address" valid:"-"`
@@ -75,7 +74,6 @@ func NewApp(config Config) *App {
 	app.stellarObserver = txobserver.NewObserver(
 		app.appCtx,
 		config.StellarBridgeAccount,
-		config.StellarBridgeAccountCreateSequence,
 		client,
 		app.NewStore(),
 	)

--- a/backend/ethereum_refund_validator.go
+++ b/backend/ethereum_refund_validator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stellar/go/support/db"
 
 	"github.com/stellar/go/support/errors"
+	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/starbridge/store"
 )
@@ -47,6 +48,9 @@ func (s EthereumRefundValidator) CanRefund(ctx context.Context, deposit store.Et
 		return errors.Wrap(err, "error getting last ledger close time")
 	}
 	withdrawalDeadline := time.Unix(deposit.BlockTime, 0).Add(s.WithdrawalWindow)
+	log.Info(lastLedgerCloseTime)
+	log.Info(deposit.BlockTime)
+	log.Info(withdrawalDeadline)
 	if !lastLedgerCloseTime.After(withdrawalDeadline) {
 		return WithdrawalWindowStillActive
 	}

--- a/backend/ethereum_refund_validator.go
+++ b/backend/ethereum_refund_validator.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stellar/go/support/db"
 
 	"github.com/stellar/go/support/errors"
-	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/support/render/problem"
 	"github.com/stellar/starbridge/store"
 )
@@ -48,9 +47,6 @@ func (s EthereumRefundValidator) CanRefund(ctx context.Context, deposit store.Et
 		return errors.Wrap(err, "error getting last ledger close time")
 	}
 	withdrawalDeadline := time.Unix(deposit.BlockTime, 0).Add(s.WithdrawalWindow)
-	log.Info(lastLedgerCloseTime)
-	log.Info(deposit.BlockTime)
-	log.Info(withdrawalDeadline)
 	if !lastLedgerCloseTime.After(withdrawalDeadline) {
 		return WithdrawalWindowStillActive
 	}

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -225,19 +225,18 @@ func (i *Test) StartStarbridge(id int, config Config, ingestSequence uint32) err
 	i.signerKeys[id] = keypair.MustRandom()
 
 	i.app[id] = app.NewApp(app.Config{
-		Port:                               9000 + uint16(id),
-		PostgresDSN:                        fmt.Sprintf("postgres://postgres:mysecretpassword@%s:5641/starbridge%d?sslmode=disable", dockerHost, id),
-		HorizonURL:                         fmt.Sprintf("http://%s:8000/", dockerHost),
-		NetworkPassphrase:                  StandaloneNetworkPassphrase,
-		StellarBridgeAccount:               i.mainAccount.GetAccountID(),
-		StellarBridgeAccountCreateSequence: ingestSequence,
-		StellarPrivateKey:                  i.signerKeys[id].Seed(),
-		EthereumRPCURL:                     EthereumRPCURL,
-		EthereumBridgeAddress:              EthereumBridgeAddress,
-		EthereumBridgeConfigVersion:        0,
-		EthereumPrivateKey:                 ethPrivateKeys[id],
-		EthereumFinalityBuffer:             config.EthereumFinalityBuffer,
-		WithdrawalWindow:                   config.WithdrawalWindow,
+		Port:                        9000 + uint16(id),
+		PostgresDSN:                 fmt.Sprintf("postgres://postgres:mysecretpassword@%s:5641/starbridge%d?sslmode=disable", dockerHost, id),
+		HorizonURL:                  fmt.Sprintf("http://%s:8000/", dockerHost),
+		NetworkPassphrase:           StandaloneNetworkPassphrase,
+		StellarBridgeAccount:        i.mainAccount.GetAccountID(),
+		StellarPrivateKey:           i.signerKeys[id].Seed(),
+		EthereumRPCURL:              EthereumRPCURL,
+		EthereumBridgeAddress:       EthereumBridgeAddress,
+		EthereumBridgeConfigVersion: 0,
+		EthereumPrivateKey:          ethPrivateKeys[id],
+		EthereumFinalityBuffer:      0,
+		WithdrawalWindow:            24 * time.Hour,
 	})
 
 	i.runningApps.Add(2)

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -236,7 +236,7 @@ func (i *Test) StartStarbridge(id int, config Config, ingestSequence uint32) err
 		EthereumBridgeConfigVersion: 0,
 		EthereumPrivateKey:          ethPrivateKeys[id],
 		EthereumFinalityBuffer:      0,
-		WithdrawalWindow:            24 * time.Hour,
+		WithdrawalWindow:            config.WithdrawalWindow,
 	})
 
 	i.runningApps.Add(2)

--- a/stellar/txobserver/main.go
+++ b/stellar/txobserver/main.go
@@ -2,15 +2,15 @@ package txobserver
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/hex"
 	"net/http"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/protocols/horizon/operations"
 	slog "github.com/stellar/go/support/log"
+	"github.com/stellar/go/toid"
 	"github.com/stellar/starbridge/store"
 )
 
@@ -23,23 +23,34 @@ type Observer struct {
 	store  *store.DB
 	log    *slog.Entry
 
-	bridgeAccountCreateSequence uint32
+	ledgerSequence uint32
+	catchup        bool
 }
 
 func NewObserver(
 	ctx context.Context,
 	bridgeAccount string,
-	bridgeAccountCreateSequence uint32,
 	client *horizonclient.Client,
 	store *store.DB,
 ) *Observer {
 	o := &Observer{
-		ctx:                         ctx,
-		bridgeAccount:               bridgeAccount,
-		bridgeAccountCreateSequence: bridgeAccountCreateSequence,
-		client:                      client,
-		store:                       store,
-		log:                         slog.DefaultLogger.WithField("service", "stellar_txobserver"),
+		ctx:           ctx,
+		bridgeAccount: bridgeAccount,
+		client:        client,
+		store:         store,
+		log:           slog.DefaultLogger.WithField("service", "stellar_txobserver"),
+	}
+
+	ledgerSeq, err := o.store.GetLastLedgerSequence(context.Background())
+	if err != nil {
+		o.log.Fatalf("Unable to load last ledger sequence from db: %v", err)
+	}
+
+	if ledgerSeq == 0 {
+		// Perform catchup on the first call to ProcessNewLedgers
+		o.catchup = true
+	} else {
+		o.ledgerSequence = ledgerSeq
 	}
 
 	return o
@@ -47,16 +58,16 @@ func NewObserver(
 
 func (o *Observer) ProcessNewLedgers() {
 	for o.ctx.Err() == nil {
-		if ledgerSeq, err := o.store.GetLastLedgerSequence(context.Background()); err != nil {
-			o.log.Errorf("Unable to load last ledger sequence from db: %v", err)
-		} else {
-			if ledgerSeq == 0 {
-				ledgerSeq = o.bridgeAccountCreateSequence
-			} else {
-				ledgerSeq++
+		if o.catchup {
+			err := o.catchupLedgers()
+			if err != nil {
+				o.log.WithFields(slog.F{"error": err}).Error("Error catching up")
 			}
+			o.catchup = false
+		} else {
 			// Get ledger data first to ensure there are no gaps
-			if ledger, err := o.client.LedgerDetail(ledgerSeq); err != nil {
+			ledger, err := o.client.LedgerDetail(o.ledgerSequence)
+			if err != nil {
 				if herr, ok := err.(*horizonclient.Error); ok && herr.Response.StatusCode == http.StatusNotFound {
 					// Ledger not found means we reached the latest ledger
 					return
@@ -64,16 +75,95 @@ func (o *Observer) ProcessNewLedgers() {
 					o.log.WithField("error", err).Error("Error getting ledger details")
 				}
 			} else {
-				o.log.WithField("sequence", ledgerSeq).Info("Processing ledger...")
-				if err := o.processSingleLedger(ledger); err != nil {
-					o.log.WithFields(slog.F{"error": err, "sequence": ledgerSeq}).Error("Error processing a single ledger details")
+				o.log.WithField("sequence", o.ledgerSequence).Info("Processing ledger...")
+
+				err = o.processSingleLedger(ledger)
+				if err != nil {
+					o.log.WithFields(slog.F{"error": err, "sequence": o.ledgerSequence}).Error("Error processing a single ledger details")
 				} else {
+					o.ledgerSequence++
 					continue // without time.Sleep
 				}
 			}
 		}
 		time.Sleep(time.Second)
 	}
+}
+
+func (o *Observer) catchupLedgers() error {
+	root, err := o.client.Root()
+	if err != nil {
+		o.log.Fatalf("Unable to access Horizon (%s) root resource: %v", o.client.HorizonURL, err)
+	}
+
+	ledgerSeq := root.HorizonSequence
+
+	o.log.Infof("Catching up to ledger %d", ledgerSeq)
+
+	err = o.store.Session.Begin()
+	if err != nil {
+		return errors.Wrap(err, "error starting a transaction")
+	}
+
+	defer func() {
+		_ = o.store.Session.Rollback()
+	}()
+
+	// Process past bridge account payments
+	cursor := toid.AfterLedger(ledgerSeq).String()
+	previousHash := ""
+	var lastOp operations.Operation
+	for o.ctx.Err() == nil {
+		ops, err := o.client.Payments(horizonclient.OperationRequest{
+			ForAccount: o.bridgeAccount,
+			Cursor:     cursor,
+			Order:      horizonclient.OrderDesc,
+			Limit:      200,
+			Join:       "transactions",
+		})
+		if err != nil {
+			return errors.Wrap(err, "error getting operations")
+		}
+
+		if len(ops.Embedded.Records) == 0 {
+			break
+		}
+
+		err = o.processOpsSinglePage(ops.Embedded.Records, previousHash)
+		if err != nil {
+			return err
+		}
+
+		lastOp = ops.Embedded.Records[len(ops.Embedded.Records)-1]
+		cursor = lastOp.PagingToken()
+		previousHash = lastOp.GetBase().TransactionHash
+	}
+
+	if o.ctx.Err() != nil {
+		return o.ctx.Err()
+	}
+
+	// At this point we reached the beginning of account history. Ensure the
+	// first op is creating it.
+	if createAccountOp, ok := lastOp.(operations.CreateAccount); !(ok && createAccountOp.Account == o.bridgeAccount) {
+		o.log.Fatal("Reached the end of history but operation creating bridge account not found")
+	}
+
+	// Update sequence number to the ledgerSeq-1
+	// Ledger close time will be updated after returning to ProcessNewLedgers.
+	err = o.store.UpdateLastLedgerSequence(context.TODO(), uint32(ledgerSeq))
+	if err != nil {
+		return errors.Wrap(err, "error updating last ledger sequence")
+	}
+
+	err = o.store.Session.Commit()
+	if err != nil {
+		return errors.Wrap(err, "error commiting a transaction")
+	}
+
+	o.ledgerSequence = uint32(ledgerSeq)
+
+	return nil
 }
 
 func (o *Observer) processSingleLedger(ledger horizon.Ledger) error {
@@ -104,39 +194,14 @@ func (o *Observer) processSingleLedger(ledger horizon.Ledger) error {
 			break
 		}
 
-		for _, op := range ops.Embedded.Records {
-			baseOp := op.GetBase()
-
-			// Update cursor instantly because we can continue later
-			cursor = op.PagingToken()
-
-			// Ignore ops not coming from bridge account
-			if baseOp.SourceAccount != o.bridgeAccount {
-				continue
-			}
-
-			tx := baseOp.Transaction
-			if tx.MemoType != "hash" || tx.Memo == "" || !tx.Successful ||
-				// Skip inserting transactions with multiple ops. Currently Starbridge
-				// does not create such transactions but it can change in the future.
-				previousHash == baseOp.TransactionHash {
-				continue
-			}
-			memoBytes, err := base64.StdEncoding.DecodeString(tx.Memo)
-			if err != nil {
-				return errors.Wrapf(err, "error decoding memo: %s", tx.Memo)
-			}
-
-			err = o.store.InsertHistoryStellarTransaction(context.TODO(), store.HistoryStellarTransaction{
-				Hash:     tx.Hash,
-				Envelope: tx.EnvelopeXdr,
-				MemoHash: hex.EncodeToString(memoBytes),
-			})
-			if err != nil {
-				return errors.Wrapf(err, "error inserting history transaction: %s", tx.Hash)
-			}
-			previousHash = baseOp.TransactionHash
+		err = o.processOpsSinglePage(ops.Embedded.Records, previousHash)
+		if err != nil {
+			return err
 		}
+
+		lastOp := ops.Embedded.Records[len(ops.Embedded.Records)-1].GetBase()
+		cursor = lastOp.PagingToken()
+		previousHash = lastOp.TransactionHash
 	}
 
 	err = o.store.UpdateLastLedgerSequence(context.TODO(), uint32(ledger.Sequence))
@@ -155,5 +220,36 @@ func (o *Observer) processSingleLedger(ledger horizon.Ledger) error {
 	}
 
 	o.log.WithField("sequence", ledger.Sequence).Info("Processed ledger")
+	return nil
+}
+
+func (o *Observer) processOpsSinglePage(ops []operations.Operation, previousHash string) error {
+	for _, op := range ops {
+		baseOp := op.GetBase()
+
+		// Ignore ops not coming from bridge account
+		if baseOp.SourceAccount != o.bridgeAccount {
+			continue
+		}
+
+		tx := baseOp.Transaction
+		if tx.MemoType != "hash" || tx.Memo == "" || !tx.Successful ||
+			// Skip inserting transactions with multiple ops. Currently Starbridge
+			// does not create such transactions but it can change in the future.
+			previousHash == baseOp.TransactionHash {
+			continue
+		}
+
+		err := o.store.InsertHistoryStellarTransaction(context.TODO(), store.HistoryStellarTransaction{
+			Hash:     tx.Hash,
+			Envelope: tx.EnvelopeXdr,
+			MemoHash: tx.Memo,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "error inserting history transaction: %s", tx.Hash)
+		}
+		previousHash = baseOp.TransactionHash
+	}
+
 	return nil
 }

--- a/stellar/txobserver/main.go
+++ b/stellar/txobserver/main.go
@@ -64,8 +64,9 @@ func (o *Observer) ProcessNewLedgers() {
 			err := o.catchupLedgers()
 			if err != nil {
 				o.log.WithFields(slog.F{"error": err}).Error("Error catching up")
+			} else {
+				o.catchup = false
 			}
-			o.catchup = false
 		} else {
 			// Get ledger data first to ensure there are no gaps
 			ledger, err := o.client.LedgerDetail(o.ledgerSequence)


### PR DESCRIPTION
When a new validator starts (or existing one lost it's DB) it needs to process all withdrawal transactions to prevent double spend. This commit adds this mode that will run on the first call to `ProcessNewLedgers`.

Close #74.