### PR TITLE
Revert removal of TestDeposit controller

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -241,6 +241,12 @@ func (a *App) initHTTP(config Config, client *horizonclient.Client, ethObserver 
 				EthereumFinalityBuffer: config.EthereumFinalityBuffer,
 			},
 		},
+		TestDepositHandler: &controllers.TestDeposit{
+			Store: a.NewStore(),
+			// This will crash if no asset mappings - probably fine for a demo
+			// because it requires at least one mapping.
+			Token: config.AssetMapping[0].EthereumToken,
+		},
 	})
 	if err != nil {
 		log.Fatal("unable to create http server", err)

--- a/html/main.js
+++ b/html/main.js
@@ -43,6 +43,7 @@ document.getElementById("withdraw").onclick = function() {
             return new Promise(async (resolve, reject) => {
                 var form = new FormData();
                 form.append("transaction_hash", document.getElementById("transaction_hash").value);
+                form.append("log_index", "1");
                 form.append("tx_expiration_timestamp", Math.ceil(Date.now()/1000)+5*60);
 
                 var status = document.getElementById("status"+j)

--- a/httpx/server.go
+++ b/httpx/server.go
@@ -37,6 +37,8 @@ type ServerConfig struct {
 	StellarRefundHandler      *controllers.StellarRefundHandler
 	EthereumWithdrawalHandler *controllers.EthereumWithdrawalHandler
 	EthereumRefundHandler     *controllers.EthereumRefundHandler
+
+	TestDepositHandler *controllers.TestDeposit
 }
 
 type Server struct {
@@ -108,6 +110,9 @@ func (s *Server) initMux(serverConfig ServerConfig) {
 	mux.Method(http.MethodPost, "/stellar/withdraw/ethereum", serverConfig.EthereumWithdrawalHandler)
 	mux.Method(http.MethodPost, "/ethereum/refund", serverConfig.EthereumRefundHandler)
 	mux.Method(http.MethodPost, "/stellar/refund", serverConfig.StellarRefundHandler)
+
+	// Demo routes
+	mux.Method(http.MethodPost, "/deposit", serverConfig.TestDepositHandler)
 
 	staticServer := http.FileServer(http.FS(html.Files))
 	mux.Handle("/*", staticServer)

--- a/starbridge_example.cfg
+++ b/starbridge_example.cfg
@@ -3,8 +3,12 @@ admin_port=6060
 horizon_url="https://horizon-testnet.stellar.org"
 postgres_dsn="postgres://localhost:5432/starbridge?sslmode=disable"
 stellar_bridge_account="GD6FUM7LF762FFNT2R6JBGX6ME6KXUO7P4FRVFZZR25OMIUGHFSFT66R"
-stellar_bridge_birth_sequence=41481689
 ethereum_rpc_url="https://ethereum-goerli-rpc.allthatnode.com"
 ethereum_bridge_address="0x31995201773da53f950f15278ea1538ea37a68a1"
 ethereum_private_key="51138e68e8a5fa906d38c5b42bc01b805d7adb3fce037743fb406bb10aa83307"
 ethereum_bridge_config_version=0
+stellar_private_key="SDFKSHMOCZVZGVHIJYD2XKGJ6H7QR4OGUG7NYSR5TO254CFPS2DMESPS"
+[[asset_mapping]]
+stellar_asset="EUR:GAJKCRY6CIOXRIVK55ALOOJA327XN4JZ5KKN7YCTT3WM5W6BMFXMVQC2"
+ethereum_token="0x31995201773da53f950f15278ea1538ea37a68a1"
+stellar_to_ethereum="1"


### PR DESCRIPTION
Revert `TestDeposit` controller removed in https://github.com/stellar/starbridge/commit/477c45dab82e81d6e2ef22a00ee34f57f5c2e298 to ensure demo app works. Updated `starbridge_example.conf` to allow testing Starbridge locally.