### PR TITLE
Switch Ubuntu base image to 22.04 from 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . ./
 RUN go install github.com/stellar/starbridge
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt-get update
 RUN apt-get install -y ca-certificates
 COPY --from=builder /go/bin/starbridge ./


### PR DESCRIPTION
### What

Switch Ubuntu to 22.04 from 20.04
### Why

We are moving other images to 22.04, this change improves consistency across SDF docker images.
